### PR TITLE
Add two-input decoder example

### DIFF
--- a/examples/Decoder.hdl
+++ b/examples/Decoder.hdl
@@ -1,0 +1,19 @@
+/**
+ * Decoder:
+ *
+ * Assert one of four outputs based on two inputs
+ */
+
+CHIP Decoder {
+  IN a, b;
+  OUT o1, o2, o3, o4;
+
+  PARTS:
+
+  Not(in=a, out=not_a);
+  Not(in=b, out=not_b);
+  And(a=not_a, b=not_b, out=o1);
+  And(a=not_a, b=b, out=o2);
+  And(a=a, b=not_b, out=o3);
+  And(a=a, b=b, out=o4);
+}


### PR DESCRIPTION
I added one of the first examples of a composite gate from a lecture on digital circuits, the decoder. It reads `n` inputs and asserts exactly one of `2^n` outputs, sort of like a `switch` statement over all input combinations. I built the one with two inputs from `Not` and `And` gates.

Are there any tests for examples? I could not find any.