### PR TITLE
Correct number range for random pin integer values

### DIFF
--- a/src/bin/hdl-js-cli.js
+++ b/src/bin/hdl-js-cli.js
@@ -298,7 +298,7 @@ function generateTruthTable(GateClass) {
       inputPins.forEach(input => {
         const size = input.size || 1;
         const name = typeof input === 'string' ? input : input.name;
-        row[name] = randomNumberInRange(0, Math.pow(2, size));
+        row[name] = randomNumberInRange(0, Math.pow(2, size) - 1);
       });
       inputData.push(row);
     }


### PR DESCRIPTION
So I was playing around with sign extension because I wondered if there needs to be a gate for it. I think I found a small bug in the random truth table generator from the cli. If I run 
```./bin/hdl-js --gate examples/test.hdl --describe``` on the following gate

```raw
// test.hdl
CHIP Test {
  IN a[16], b;
  OUT out;

  PARTS:
  And(a=a[0], b=b, out=out);
}
```

Then I sometimes get binary two digit values for `b`:

![image](https://user-images.githubusercontent.com/18613301/35477139-53d2e260-03bd-11e8-913d-dd51ac310810.png)

To me this looks like the random number for `b` was 2, so I corrected the corresponding `randomNumberInRange` call so the number range is `0` to `2^n - 1`.